### PR TITLE
feature/markdown-table-plugin

### DIFF
--- a/dein.toml
+++ b/dein.toml
@@ -203,6 +203,15 @@ let g:mkdp_auto_close = 0
 '''
 
 [[plugins]]
+repo = 'mattn/vim-maketable'
+
+[[plugins]]
+repo = 'dhruvasagar/vim-table-mode'
+hook_add = '''
+let g:table_mode_map_prefix = 'm'
+'''
+
+[[plugins]]
 repo = 'tpope/vim-endwise'
 
 [[plugins]]

--- a/init.vim
+++ b/init.vim
@@ -123,11 +123,14 @@ vnoremap <leader>P "*P
 nnoremap <leader>p "*p
 nnoremap <leader>P "*P
 
+" :terminal実行時に.bash_profileの読み込みを強制
+set shell=/bin/bash\ -l
+
 " カレントウィンドウの行数の1/4のサイズでsplitしてターミナル表示
 command! Sterminal call SplitTerminal()
 nnoremap <leader>tt :Sterminal<CR>i
 function! SplitTerminal()
-    let l:win_height = winheight('%') / 4
+    let l:win_height = &lines / 4
     execute 'botright '.l:win_height.'split'
     execute 'terminal'
     execute 'set nonumber'


### PR DESCRIPTION
* markdownのtable入力支援プラグインの追加
* `:terminal` 時に.bash_profileを読み込むように変更
* `SplitTerminal()` の分割時の行数指定修正