### PR TITLE
fix/coc-key-bind

### DIFF
--- a/dein_toml/coc.toml
+++ b/dein_toml/coc.toml
@@ -30,9 +30,6 @@ hook_add = '''
   \ coc#refresh()
   inoremap <expr><S-TAB> coc#pum#visible() ? coc#pum#prev(1) : "\<C-h>"
 
-  " 補完候補の確定
-  inoremap <expr> <cr> coc#pum#visible() ? coc#pum#confirm() : "\<CR>"
-
   function! CheckBackspace() abort
     let col = col('.') - 1
     return !col || getline('.')[col - 1]  =~# '\s'

--- a/dein_toml/coc.toml
+++ b/dein_toml/coc.toml
@@ -70,6 +70,10 @@ hook_add = '''
   " シンボルのリネーム
   nmap <leader>rn <Plug>(coc-rename)
 
+  " コードのフォーマット
+  xmap <leader>f  <Plug>(coc-format-selected)
+  nmap <leader>f  <Plug>(coc-format-selected)
+
   " ドキュメントのpopup内のスクロール
   if has('nvim-0.4.0') || has('patch-8.2.0750')
     nnoremap <silent><nowait><expr> <C-f> coc#float#has_scroll() ? coc#float#scroll(1) : "\<C-f>"
@@ -79,6 +83,9 @@ hook_add = '''
     vnoremap <silent><nowait><expr> <C-f> coc#float#has_scroll() ? coc#float#scroll(1) : "\<C-f>"
     vnoremap <silent><nowait><expr> <C-b> coc#float#has_scroll() ? coc#float#scroll(0) : "\<C-b>"
   endif
+
+  " :Formatでカレントバッファのフォーマット
+  command! -nargs=0 Format :call CocActionAsync('format')
 
   " :Foldでcocによる折りたたみ
   command! -nargs=? Fold :call     CocAction('fold', <f-args>)

--- a/dein_toml/coding.toml
+++ b/dein_toml/coding.toml
@@ -10,10 +10,6 @@ hook_add = '''
   autocmd VimEnter,Colorscheme * :hi IndentGuidesEven ctermbg=236 guibg=#2b3047
 '''
 
-# Rubyのend等を補完
-[[plugins]]
-repo = 'tpope/vim-endwise'
-
 # 括弧の補完
 [[plugins]]
 repo = 'cohama/lexima.vim'

--- a/package_setup.sh
+++ b/package_setup.sh
@@ -33,6 +33,7 @@ function python3_setup() {
         neovim \
         pylint \
         flake8 \
+        autopep8 \
         cfn-lint
 }
 


### PR DESCRIPTION
* coc.nvimで機能していなかった<CR>のキーバインドの削除
* パッケージインストールスクリプトにautopep8追加(format用)
* format関連のキーバインド追加
* 機能が重複していたプラグインを削除