### PR TITLE
feature/fix-lexima-coc-keymap-conflict

### DIFF
--- a/lua/plugins/coc.lua
+++ b/lua/plugins/coc.lua
@@ -26,6 +26,9 @@ return {
       -- statuscolumnを常に1列は表示する
       vim.opt.signcolumn = 'auto:1-9'
 
+      -- lexima.vimのデフォルトルールを設定
+      vim.fn['lexima#set_default_rules']()
+
       local keyset = vim.keymap.set
 
       -- 自動補完
@@ -40,7 +43,8 @@ return {
       keyset("i", "<S-TAB>", [[coc#pum#visible() ? coc#pum#prev(1) : "\<C-h>"]], opts)
 
       -- 補完の確定
-      keyset("i", "<cr>", [[coc#pum#visible() ? coc#pum#confirm() : "\<C-g>u\<CR>\<c-r>=coc#on_enter()\<CR>"]], opts)
+      -- lexima.vimの動作と共存させる
+      keyset("i", "<cr>", [[coc#pum#visible() ? coc#pum#confirm() : "\<C-g>u\<C-r>=lexima#expand('<LT>CR>', 'i')\<CR><c-r>=coc#on_enter()\<CR>"]], opts)
 
       -- <c-Space>での補完の実行
       keyset("i", "<c-space>", "coc#refresh()", {silent = true, expr = true})
@@ -128,5 +132,8 @@ return {
       vim.api.nvim_create_autocmd(event, {pattern = {'*'}, command = 'hi CocHintHighlight cterm=underline gui=undercurl'})
       vim.api.nvim_create_autocmd(event, {pattern = {'*'}, command = 'hi CocHighlightText ctermbg=238 guibg=#525c88'})
     end,
+    dependencies = {
+      'cohama/lexima.vim',
+    }
   },
 }

--- a/lua/plugins/coding.lua
+++ b/lua/plugins/coding.lua
@@ -16,7 +16,13 @@ return {
   },
 
   -- 括弧の補完
-  'cohama/lexima.vim',
+  {
+    'cohama/lexima.vim',
+    init = function()
+      -- coc.nvimの<CR>のキーマップと競合するため、coc.nvim側でキーマップを設定する
+      vim.g.lexima_no_default_rules = 1
+    end,
+  },
 
   -- Markdownプレビュー
   {


### PR DESCRIPTION
* coc.nvimとlexima.vimの `<CR>` の動作が競合していたのを修正