### PR TITLE
feature/disable-scrollbar-cursor

### DIFF
--- a/lua/plugins/ui.lua
+++ b/lua/plugins/ui.lua
@@ -76,6 +76,9 @@ return {
           Hint = {color = colors.hint},
           Misc = {color = colors.purple},
         },
+        handlers = {
+          cursor = false,
+        },
       })
     end,
   }


### PR DESCRIPTION
* 文字が隠れるのでスクロールバーのカーソル位置の表示を無効化