### PR TITLE
feature/fix-signature-help-settings

### DIFF
--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -79,9 +79,8 @@ return {
       -- lspconfig-bundler呼び出し
       require('lspconfig-bundler').setup()
 
-      -- snippet supportの有効化
-      local capabilities = vim.lsp.protocol.make_client_capabilities()
-      capabilities.textDocument.completion.completionItem.snippetSupport = true
+      -- cmp-nvim-lsp向けの設定
+      local capabilities = require('cmp_nvim_lsp').default_capabilities()
 
       -- mason-lspconfigに渡すhandler
       local handlers = {

--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -176,6 +176,8 @@ return {
       vim.keymap.set('n', '<Leader>hh', '<CMD>lua vim.lsp.buf.hover()<CR>', {noremap = true, silent = true})
       -- <Leader>he でdiagnosticをfloatで表示
       vim.keymap.set('n', '<Leader>he', '<CMD>lua vim.diagnostic.open_float(nil, {focus=false})<CR>', {noremap = true, silent = true})
+      -- 挿入モードの<C-s>で手動でsignature helpを表示させる
+      vim.keymap.set('i', '<C-s>', '<CMD>lua vim.lsp.buf.signature_help()<CR>', {noremap = true, silent = true})
 
       -- diagnosticsのfloatのborderの設定
       vim.diagnostic.config({
@@ -187,6 +189,14 @@ return {
         vim.lsp.handlers.hover,
         {
           border = 'rounded',
+        }
+      )
+
+      -- 手動で出したsignature helpのborder設定
+      vim.lsp.handlers['textDocument/signatureHelp'] = vim.lsp.with(
+        vim.lsp.handlers.signature_help,
+        {
+          border = 'rounded'
         }
       )
 


### PR DESCRIPTION
* nvim-cmp経由でsignature helpが出ない場合に手動で出せるようにキーバインドを設定
* snippet supportの有効化をcmp_nvim_lspのdefault_capabilities()で設定するように変更