### PR TITLE
feature/mod-key-bind-buf-lspsaga

### DIFF
--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -40,7 +40,7 @@ return {
         definition = {
           keys = {
             edit = '<C-o>',
-            split = '<C-s>',
+            split = '<C-x>',
             vsplit = '<C-v>',
             tabe = '<C-t>',
           },
@@ -48,7 +48,7 @@ return {
         finder = {
           keys = {
             edit = '<C-o>',
-            split = '<C-s>',
+            split = '<C-x>',
             vsplit = '<C-v>',
             tabe = '<C-t>',
           },

--- a/lua/plugins/ui.lua
+++ b/lua/plugins/ui.lua
@@ -56,7 +56,19 @@ return {
   },
 
   -- バッファ操作
-  'jeetsukumaran/vim-buffergator',
+  {
+    'jeetsukumaran/vim-buffergator',
+    init = function()
+      --画面下に表示
+      vim.g.buffergator_viewport_split_policy = 'B'
+      -- デフォルトのグローバルキーマップを削除
+      vim.g.buffergator_suppress_keymaps = 1
+    end,
+    keys = {
+      { '<Leader>bb', '<Cmd>BuffergatorToggle<CR>', mode = 'n', {noremap = true, silent = true} },
+      { '<Leader>bt', '<Cmd>BuffergatorTabsToggle<CR>', mode = 'n', {noremap = true, silent = true} },
+    },
+  },
 
   -- スクロールバー
   {


### PR DESCRIPTION
* vim-buffergatorの表示位置とキーバインドの変更
* lspsagaの定義元/参照元ジャンプの水平分割時のキーバインドをnvim-treeに合わせて `<C-x>` に変更