### PR TITLE
feature/fix-lsp-hover

### DIFF
--- a/lua/plugins/coding.lua
+++ b/lua/plugins/coding.lua
@@ -24,7 +24,20 @@ return {
     'MeanderingProgrammer/render-markdown.nvim',
     config = true,
     opts = {
-      enabled = false,
+      overrides = {
+        buftype = {
+          nofile = {
+            enabled = false,
+            -- hoverのconceallevelの設定
+            win_options = {
+              conceallevel = {
+                default = 2,
+                rendered = 3,
+              },
+            },
+          },
+        },
+      },
     },
     dependencies = {
       'nvim-treesitter/nvim-treesitter',

--- a/lua/plugins/lsp-config.lua
+++ b/lua/plugins/lsp-config.lua
@@ -120,15 +120,8 @@ return {
       })
 
       -- <Leader>hh でhoverするように設定
-      vim.keymap.set('n', '<Leader>hh', '<CMD>lua vim.lsp.buf.hover()<CR>', { noremap = true, silent = true })
+      vim.keymap.set('n', '<Leader>hh', '<CMD>lua vim.lsp.buf.hover({ border = "rounded" })<CR>', { noremap = true, silent = true })
 
-      -- hover時のwindowのborderの設定
-      vim.lsp.handlers['textDocument/hover'] = vim.lsp.with(
-        vim.lsp.handlers.hover,
-        {
-          border = 'rounded',
-        }
-      )
       -- <Leader>he でdiagnosticをfloatで表示
       vim.keymap.set('n', '<Leader>he', '<CMD>lua vim.diagnostic.open_float(nil, {focus=false})<CR>',
         { noremap = true, silent = true })

--- a/lua/plugins/lsp-config.lua
+++ b/lua/plugins/lsp-config.lua
@@ -119,9 +119,6 @@ return {
         handlers = handlers,
       })
 
-      -- <Leader>hh でhoverするように設定
-      vim.keymap.set('n', '<Leader>hh', '<CMD>lua vim.lsp.buf.hover({ border = "rounded" })<CR>', { noremap = true, silent = true })
-
       -- <Leader>he でdiagnosticをfloatで表示
       vim.keymap.set('n', '<Leader>he', '<CMD>lua vim.diagnostic.open_float(nil, {focus=false})<CR>',
         { noremap = true, silent = true })

--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -61,6 +61,9 @@ return {
         },
       })
 
+      -- hover
+      vim.keymap.set('n', '<Leader>hh', '<CMD>Lspsaga hover_doc<CR>', { noremap = true, silent = true })
+
       -- 定義元ジャンプ
       vim.keymap.set('n', 'gd', '<CMD>Lspsaga peek_definition<CR>', { noremap = true, silent = true })
 


### PR DESCRIPTION
* 非推奨となったhoverの設定を削除
* hoverをlspsagaで表示するように変更
* render-markdownをデフォルト有効化
    * hover上では無効化