### PR TITLE
feature/add-cmp-cmdline-target

### DIFF
--- a/lua/plugins/completion.lua
+++ b/lua/plugins/completion.lua
@@ -97,8 +97,8 @@ return {
           end, { "i", "s" }),
         }),
 
-        -- / の補完
-        cmp.setup.cmdline('/', {
+        -- /、? の補完
+        cmp.setup.cmdline({ '/', '?' }, {
           mapping = cmp.mapping.preset.cmdline(),
           sources = { cmp_buffer_config },
         }),


### PR DESCRIPTION
* cmp-bufferのソース有効化範囲に `?` を追加